### PR TITLE
Fix queries in dags formerly using the Astro SDK

### DIFF
--- a/dags/extract_historical_weather_data.py
+++ b/dags/extract_historical_weather_data.py
@@ -45,7 +45,7 @@ extract_dataset = Dataset("extract")
 # instantiate a DAG with the @dag decorator and set DAG parameters (see: https://www.astronomer.io/docs/learn/airflow-dag-parameters)
 @dag(
     start_date=datetime(2023, 1, 1), # date after which the DAG can be scheduled
-    schedule=[start_dataset], # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
+    schedule=None, # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
     catchup=False, # see: https://www.astronomer.io/docs/learn/rerunning-dags#catchup
     max_consecutive_failed_dag_runs=5, # auto-pauses the DAG after 5 consecutive failed runs, experimental
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls

--- a/dags/extract_historical_weather_data.py
+++ b/dags/extract_historical_weather_data.py
@@ -30,6 +30,7 @@ t_log = logging.getLogger("airflow.task")
 # ------------------ #
 
 start_dataset = Dataset("start")
+extract_dataset = Dataset("extract")
 
 # -------------- #
 # DAG Definition #
@@ -44,7 +45,7 @@ start_dataset = Dataset("start")
 # instantiate a DAG with the @dag decorator and set DAG parameters (see: https://www.astronomer.io/docs/learn/airflow-dag-parameters)
 @dag(
     start_date=datetime(2023, 1, 1), # date after which the DAG can be scheduled
-    schedule=None, # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
+    schedule=[start_dataset], # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
     catchup=False, # see: https://www.astronomer.io/docs/learn/rerunning-dags#catchup
     max_consecutive_failed_dag_runs=5, # auto-pauses the DAG after 5 consecutive failed runs, experimental
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls
@@ -113,7 +114,7 @@ def extract_historical_weather_data(): # by default the dag_id is the name of th
     historical_weather = get_historical_weather(coordinates=coordinates)
 
     @task(
-        outlets=[Dataset("duckdb://include/dwh/historical_weather_data")],
+        outlets=[Dataset("duckdb://include/dwh/historical_weather_data"), extract_dataset],
     )
     def turn_json_into_table(
         duckdb_conn_id: str,

--- a/dags/transform_climate_data.py
+++ b/dags/transform_climate_data.py
@@ -63,13 +63,13 @@ def transform_climate_data(): # by default the dag_id is the name of the decorat
         t_log.info("Creating a table for the climate data in the database.")
 
         cursor.sql(
-            f"CREATE TABLE IF NOT EXISTS {output_table} AS SELECT * FROM {in_climate};"
+            f"CREATE OR REPLACE TABLE {output_table} (date DATE, decade_average_temp INTEGER, year_average_temp INTEGER, month_average_temp INTEGER, day_average_temp INTEGER);"
         )
 
         t_log.info("Performing a transformation on the data.")
 
         cursor.sql(
-            f"INSERT INTO {output_table} SELECT CAST(dt AS DATE) AS date, AVG(LandAverageTemperature) OVER(PARTITION BY YEAR(CAST(dt AS DATE))/10*10) AS decade_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY YEAR(CAST(dt AS DATE))) AS year_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY MONTH(CAST(dt AS DATE))) AS month_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY CAST(dt AS DATE)) AS day_average_temp, FROM {in_climate};"
+            f"SELECT CAST(dt AS DATE) AS date, AVG(LandAverageTemperature) OVER(PARTITION BY YEAR(CAST(dt AS DATE))/10*10) AS decade_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY YEAR(CAST(dt AS DATE))) AS year_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY MONTH(CAST(dt AS DATE))) month_average_temp, AVG(LandAverageTemperature) OVER(PARTITION BY CAST(dt AS DATE)) AS day_average_temp, FROM {in_climate};"
         )
         cursor.close()
 

--- a/dags/transform_historical_weather.py
+++ b/dags/transform_historical_weather.py
@@ -18,10 +18,13 @@ from include.global_variables import constants as c
 # use the Airflow task logger to log information to the task logs (or use print())
 t_log = logging.getLogger("airflow.task")
 
+# Dataset definition for data-aware scheduling
+extract_dataset = Dataset("extract")
+
 # -------------- #
 # DAG Definition #
 # -------------- #
-extract_dataset = Dataset("extract")
+
 
 # ---------- #
 # Exercise 1 #
@@ -33,7 +36,7 @@ extract_dataset = Dataset("extract")
 @dag(
     start_date=datetime(2023, 1, 1), # date after which the DAG can be scheduled
     # this DAG runs as soon as the climate and weather data is ready in DuckDB
-    schedule=[extract_dataset], # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
+    schedule=None, # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
     catchup=False,
     max_consecutive_failed_dag_runs=5, # auto-pauses the DAG after 5 consecutive failed runs, experimental
     max_active_runs=1,  # only allow one concurrent run of this DAG, prevents parallel DuckDB calls

--- a/solutions_exercises/solution_extract_historical_weather_data.py
+++ b/solutions_exercises/solution_extract_historical_weather_data.py
@@ -23,19 +23,8 @@ from include.meterology_utils import (
     get_historical_weather_from_city_coordinates,
 )
 
-# ----------------- #
-# Astro SDK Queries #
-# ----------------- #
-
-
-@aql.dataframe(pool="duckdb")
-def turn_json_into_table(in_json):
-    """Converts the list of JSON input into one pandas dataframe."""
-    if type(in_json) == dict:
-        df = pd.DataFrame(in_json)
-    else:
-        df = pd.concat([pd.DataFrame(d) for d in in_json], ignore_index=True)
-    return df
+start_dataset = Dataset("start")
+extract_dataset = Dataset("extract")
 
 
 # --- #
@@ -95,7 +84,7 @@ def solution_extract_historical_weather_data():
     historical_weather = get_historical_weather.expand(coordinates=coordinates)
 
     @task(
-        outlets=[Dataset("duckdb://include/dwh/historical_weather_data")],
+        outlets=[Dataset("duckdb://include/dwh/historical_weather_data"), extract_dataset],
     )
     def turn_json_into_table(
         duckdb_conn_id: str,


### PR DESCRIPTION
A fresh clone of the project revealed some issues with the new queries used in place of the SDK-based implementation.

Also, I found that when scheduling the transform DAG on the duckdb database in include, the DAG entered a loop, running about 300 times within a few minutes and crashing the streamlit app.

This adds missing create table queries so streamlit functions as expected. It also adds a new dataset for scheduling the transform DAG. Also included: fixes in the solutions dags.